### PR TITLE
fix: '' is supposed to contain 'ant-form-item-required', but it doesn't

### DIFF
--- a/frontend/src/pages/Company/config.js
+++ b/frontend/src/pages/Company/config.js
@@ -17,6 +17,7 @@ export const fields = {
   },
   country: {
     type: 'country',
+    required: true,
   },
   phone: {
     type: 'phone',

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo ============================
+echo Starting backend setup...
+echo ============================
+cd backend
+
+echo Installing backend dependencies...
+npm install
+echo Starting backend server in new window...
+npm run start &
+
+cd ..
+echo ============================
+echo Starting frontend setup...
+echo ============================
+
+cd frontend
+echo Installing frontend dependencies...
+npm install
+echo Starting frontend server...
+npm run dev


### PR DESCRIPTION

        Fix issue: "'' is supposed to contain 'ant-form-item-required', but it doesn't"
        The description that explains the issue is: "Country field should be mandatory."
        Test case run: https://app.testrigor.com/suites/gEMN6YtQ9ao4B9wjp/runs/7k4d67H6MzjZBM2pJ
        