### PR TITLE
Add codeCake AI Agent text to auth page

### DIFF
--- a/frontend/src/modules/AuthModule/SideContent.jsx
+++ b/frontend/src/modules/AuthModule/SideContent.jsx
@@ -50,6 +50,7 @@ export default function SideContent() {
           </li>
         </ul>
         <Divider />
+        <Text style={{ display: 'block', textAlign: 'center' }}>codeCake AI Agent</Text>
         <div
           style={{
             display: 'flex',


### PR DESCRIPTION
**PR Generated by testRigor CodeGen AI Agent**

## Summary
Added a centered "codeCake AI Agent" text label to the authentication side content, placed below the divider and above the existing flex container.

### Test case error
Page doesn't contain 'codeCake AI Agent' but it's supposed to in command 'check that page contains "codeCake AI Agent"'

### Additional context
### Test case run
- Status: ✅ Execution Completed
- https://app.testrigor.com/suites/RJZjKkjT5AXfaXdx9/runs/tM8vJEWgovhRtnM6i

### Conflict Resolution
### Ticket
### CodeCake Task Logs
- http://20.51.220.99:3000/test-suites/RJZjKkjT5AXfaXdx9/code-cake/sBGgxfxRBQXWM7XPm/logs

